### PR TITLE
Some fixes

### DIFF
--- a/ol-emacs-slack.el
+++ b/ol-emacs-slack.el
@@ -103,7 +103,8 @@
 
 (defun ol/slack-store-link ()
   "Store a link to a man page."
-  (when (eq major-mode 'slack-message-buffer-mode)
+  (when (or (eq major-mode 'slack-message-buffer-mode)
+            (eq major-mode 'slack-thread-message-buffer-mode))
     (let* ((buf slack-current-buffer)
            (team (slack-buffer-team buf))
            (team-name (oref team name))

--- a/ol-emacs-slack.el
+++ b/ol-emacs-slack.el
@@ -80,13 +80,10 @@
 (defun ol/slack-select-im (team-object room-with-prefix)
   "Return im object from TEAM-OBJECT and ROOM-WITH-PREFIX string."
   (let ((room (second (s-split " - " room-with-prefix))))
-    (when (and
-           (not (s-lowercase? room)))
-      (ol/slack-room-select
-       (s-trim (s-replace "#" "" (s-replace "Thread in #" "" room-with-prefix)))
-       (slack-team-ims team-object)
-       team-object)
-      )))
+    (ol/slack-room-select
+     (s-trim (s-replace "#" "" (s-replace "Thread in #" "" room-with-prefix)))
+     (slack-team-ims team-object)
+     team-object)))
 
 (defun ol/slack-string-to-room (team-object room)
   "Convert TEAM-OBJECT and ROOM name to room object."


### PR DESCRIPTION
At my day job, we are all too ~cool~ lazy for capitalized names, so with the code as it was I could not capture links to IMs.

Furthermore, now you should be able to access `org-store-link` in threads as well; following it leads to the TS message in the room the thread is in.
EDIT: To be fair, I think they link to _some_ message that started a thread in the room. Oh well :man_shrugging: 