### PR TITLE
Add support for timestamp in the link

### DIFF
--- a/ol-emacs-slack-legacy.el
+++ b/ol-emacs-slack-legacy.el
@@ -1,0 +1,100 @@
+;;; ol-emacs-slack-legacy.el --- Support for links to emacs-slack chats in Org mode
+
+;; Copyright (C) 2020 Andrea Giugliano
+
+;; Author: Andrea Giugliano <andrea-dev@hotmail.com>
+;; Version: 0.0.0
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; See documentation on https://github.com/ag91/ol-emacs-slack/
+(require 'ol)
+(require 'dash)
+(require 's)
+
+(defun ol/slack-string-to-team (team)
+  "Convert TEAM name to team object."
+  (let ((slack-completing-read-function
+         (lambda (prompt collection &optional predicate require-match
+                         initial-input hist def inherit-input-method)
+           (s-trim team))))
+    (slack-team-select)))
+
+(defun ol/room-name-equal (room channel-room)
+  "Check ROOM is equal to CHANNEL-ROOM."
+  (string=
+   (s-downcase (s-trim room))
+   (s-downcase
+    (let ((trimmed (s-trim (s-chop-prefix " * " channel-room))))
+      (if (> (length trimmed) (length room))
+          (substring trimmed 0 (length room))
+        trimmed)))))
+
+(defun ol/slack-room-select (room rooms team)
+  "Select ROOM from ROOMS and TEAM."
+  (let* ((alist (slack-room-names
+                 rooms team #'(lambda (rs) (cl-remove-if #'slack-room-hidden-p rs))))
+         (selected (cdr (cl-assoc room alist :test 'ol/room-name-equal))))
+    selected))
+
+(defun ol/slack-select-channel (team-object room-with-prefix)
+  "Return channel object from TEAM-OBJECT and ROOM-WITH-PREFIX string (as comes out from alert)."
+  (let ((room (second (s-split " - " room-with-prefix))))
+    (when (or
+           (s-lowercase? room)
+           (s-contains? "Thread in #" room))
+      (ol/slack-room-select
+       (s-trim (s-replace "#" "" (s-replace "Thread in #" "" room-with-prefix)))
+       (slack-team-channels team-object)
+       team-object))))
+
+(defun ol/slack-select-group (team-object room-with-prefix)
+  "Return group object from TEAM-OBJECT and ROOM-WITH-PREFIX string."
+  (let ((room (second (s-split " - " room-with-prefix))))
+    (when (and
+           (s-lowercase? room)
+           (s-contains? "--" room))
+      (ol/slack-room-select
+       (s-trim (s-replace "#" "" (s-replace "Thread in #" "" room-with-prefix)))
+       (slack-team-groups team-object)
+       team-object))))
+
+(defun ol/slack-select-im (team-object room-with-prefix)
+  "Return im object from TEAM-OBJECT and ROOM-WITH-PREFIX string."
+  (let ((room (second (s-split " - " room-with-prefix))))
+    (ol/slack-room-select
+     (s-trim (s-replace "#" "" (s-replace "Thread in #" "" room-with-prefix)))
+     (slack-team-ims team-object)
+     team-object)))
+
+(defun ol/slack-string-to-room (team-object room)
+  "Convert TEAM-OBJECT and ROOM name to room object."
+  (or
+   (ol/slack-select-channel team-object room)
+   (ol/slack-select-group team-object room)
+   (ol/slack-select-im team-object room)))
+
+(defun ol/slack-follow-link-legacy (link)
+  "Follow LINK with format `   team - channel'."
+  (let* ((team (--> link
+                    (s-split "-" it)
+                    first
+                    s-trim))
+         (team-object (ol/slack-string-to-team team)))
+    (slack-room-display (ol/slack-string-to-room team-object link) team-object)))
+
+(provide 'ol-emacs-slack-legacy)
+;;; ol-emacs-slack.el ends here

--- a/ol-emacs-slack.el
+++ b/ol-emacs-slack.el
@@ -75,12 +75,19 @@
 
 (defun ol/slack-follow-link (link)
   "Follow the link."
-  (let (
-        (context (ol/slack-parse-link link))
+  (if (not (string-match-p "|" link))
+      (progn
+        (require 'ol-emacs-slack-legacy)
+        (ol/slack-follow-link-legacy link)
+        (warn "This was a legacy link, please re run `M-x org-store-link' and replace the legacy link")
         )
-    (slack-room-display (plist-get context :room) (plist-get context :team))
-    (when-let (ts (plist-get context :ts))
-      (slack-buffer-goto ts))
+    (let (
+          (context (ol/slack-parse-link link))
+          )
+      (slack-room-display (plist-get context :room) (plist-get context :team))
+      (when-let (ts (plist-get context :ts))
+        (slack-buffer-goto ts))
+      )
     )
   )
 

--- a/ol-emacs-slack.el
+++ b/ol-emacs-slack.el
@@ -25,6 +25,17 @@
 (require 'dash)
 (require 's)
 
+(defgroup ol/slack nil
+  "Org mode link to slack buffers."
+  :prefix "ol/slack-"
+  :link '(url-link :tag "Github" "https://github.com/ag91/ol-emacs-slack/"))
+
+(defcustom ol/slack-follow-link-legacy-warn-user t
+  "Annoy the user till they update all their legacy links."
+  :type 'boolean
+  :group 'ol/slack)
+
+
 (org-link-set-parameters "emacs-slack"
                          :follow #'ol/slack-follow-link
                          :export #'ol/slack-export
@@ -79,7 +90,16 @@
       (progn
         (require 'ol-emacs-slack-legacy)
         (ol/slack-follow-link-legacy link)
-        (warn "This was a legacy link, please re run `M-x org-store-link' and replace the legacy link")
+        (when ol/slack-follow-link-legacy-warn-user
+          (warn (concat
+                 "This was a legacy link,"
+                 " please re run `M-x org-store-link'"
+                 " and replace the legacy link."
+                 " Or silence me by customizing"
+                 " ol/slack-follow-link-legacy-warn-user."
+                 )
+                )
+          )
         )
     (let (
           (context (ol/slack-parse-link link))

--- a/ol-emacs-slack.el
+++ b/ol-emacs-slack.el
@@ -45,12 +45,12 @@
 (defun ol/slack-parse-link (link)
   "Parse the `LINK' to find the actual team and room objects."
   (let* (
-        (split-link (s-split "|" link))
-        (team (slack-team-find (first split-link)))
-        (room (slack-room-find (second split-link) team))
-        (remaining (cddr split-link))
-        (res '())
-        )
+         (split-link (s-split "|" link))
+         (team (slack-team-find (first split-link)))
+         (room (slack-room-find (second split-link) team))
+         (remaining (cddr split-link))
+         (res '())
+         )
     (setq res (plist-put res :team team))
     (setq res (plist-put res :room room))
     (mapc
@@ -59,12 +59,12 @@
              (split-elem (s-split ":" elem))
              )
          (setq res
-          (plist-put
-           res
-           (intern (format ":%s" (first split-elem)))
-           (second split-elem)
-           )
-          )
+               (plist-put
+                res
+                (intern (format ":%s" (first split-elem)))
+                (second split-elem)
+                )
+               )
          )
        )
      remaining
@@ -96,12 +96,21 @@
            (ts (org-get-at-bol 'ts))
            (formatted_ts (org-get-at-bol 'lui-formatted-time-stamp))
            (link (ol/slack-format-link team room ts))
-           (description )
+           (description (concat "Slack message in #" room-name (if formatted_ts (format " at %s" formatted_ts) "")
+                                (if ts
+                                    (concat ": "(s-trim (buffer-substring-no-properties
+                                                         (point-at-bol)
+                                                         (point-at-eol
+                                                          ))))
+                                  ""
+                                  )
+                                )
+                        )
            )
       (org-link-store-props
        :type "emacs-slack"
        :link (concat "emacs-slack:" link)
-       :description (concat "Slack message in #" room-name (if formatted_ts (format " at %s" formatted_ts) ""))
+       :description description
        ))))
 
 (defun ol/slack-export (link description format)


### PR DESCRIPTION
So that you can go back not only to the room, but also to the
message that triggered the capture of the link.

I am not conviced with the part where the link is split then reconstructed (without the ts) to be given to `ol/slack-string-to-room`. It does not look very elegant to me. Nevertheless, IMHO, an elegant way of playing with the link would be to parse the link value only once and use this parsed object in the function rather than parsing in several places (with s-split). What is your opinion on the matter ?

Anyway, this is great to be able to go back and forth between slack and org-mode, thanks for ol-emacs-slack :-).