### PR TITLE
Adding missing require statement and updating to cl-lib vs. cl

### DIFF
--- a/ol-emacs-slack.el
+++ b/ol-emacs-slack.el
@@ -24,6 +24,8 @@
 (require 'ol)
 (require 'dash)
 (require 's)
+(require 'eieio)
+(require 'cl-lib)
 
 (defgroup ol/slack nil
   "Org mode link to slack buffers."
@@ -52,8 +54,8 @@
   "Parse the `LINK' to find the actual team and room objects."
   (let* (
          (split-link (s-split (if (s-contains? "|" link) "|" "&") link))
-         (team (slack-team-find (first split-link)))
-         (room (slack-room-find (second split-link) team))
+         (team (slack-team-find (cl-first split-link)))
+         (room (slack-room-find (cl-second split-link) team))
          (remaining (cddr split-link))
          (res '()))
     (setq res (plist-put res :team team))
@@ -64,8 +66,8 @@
          (setq res
                (plist-put
                 res
-                (intern (format ":%s" (first split-elem)))
-                (second split-elem)
+                (intern (format ":%s" (cl-first split-elem)))
+                (cl-second split-elem)
                 ))))
      remaining)
     res))


### PR DESCRIPTION
This should fix #5. 

The issue was missing require statemetns for eieio and cl-lib. In reallity it should also probably have an added require statement for emacs-slack but that wasn't giving me errors so I left it off. Also I updated from cl to cl-lib function names since I think the cl library is now deprecated. 